### PR TITLE
Add option to disable VAT on production price

### DIFF
--- a/custom_components/dynamic_energy_calculator/config_flow.py
+++ b/custom_components/dynamic_energy_calculator/config_flow.py
@@ -174,7 +174,10 @@ class DynamicEnergyCalculatorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN
         for key, default in DEFAULT_PRICE_SETTINGS.items():
             if key not in (CONF_PRICE_SENSOR, CONF_PRICE_SENSOR_GAS):
                 current = self.price_settings.get(key, default)
-                schema_fields[vol.Required(key, default=current)] = vol.Coerce(float)
+                if isinstance(default, bool):
+                    schema_fields[vol.Required(key, default=current)] = bool
+                else:
+                    schema_fields[vol.Required(key, default=current)] = vol.Coerce(float)
 
         return self.async_show_form(
             step_id=STEP_PRICE_SETTINGS,
@@ -340,7 +343,10 @@ class DynamicEnergyCalculatorOptionsFlowHandler(config_entries.OptionsFlow):
         for key, default in DEFAULT_PRICE_SETTINGS.items():
             if key not in (CONF_PRICE_SENSOR, CONF_PRICE_SENSOR_GAS):
                 current = self.price_settings.get(key, default)
-                schema_fields[vol.Required(key, default=current)] = vol.Coerce(float)
+                if isinstance(default, bool):
+                    schema_fields[vol.Required(key, default=current)] = bool
+                else:
+                    schema_fields[vol.Required(key, default=current)] = vol.Coerce(float)
 
         return self.async_show_form(
             step_id=STEP_PRICE_SETTINGS,

--- a/custom_components/dynamic_energy_calculator/const.py
+++ b/custom_components/dynamic_energy_calculator/const.py
@@ -40,6 +40,7 @@ PRICE_SETTINGS_KEYS = [
     "gas_markup_per_m3",
     "gas_surcharge_per_m3",
     "gas_standing_charge_per_day",
+    "production_price_include_vat",
 ]
 
 DEFAULT_PRICE_SETTINGS = {
@@ -53,4 +54,5 @@ DEFAULT_PRICE_SETTINGS = {
     "gas_markup_per_m3": 0.0,
     "gas_surcharge_per_m3": 0.0,
     "gas_standing_charge_per_day": 0.0,
+    "production_price_include_vat": True,
 }

--- a/custom_components/dynamic_energy_calculator/sensor.py
+++ b/custom_components/dynamic_energy_calculator/sensor.py
@@ -285,7 +285,10 @@ class DynamicEnergySensor(BaseUtilitySensor):
             ):
                 price = (price + markup_consumption + tax) * vat_factor
             elif self.source_type == SOURCE_TYPE_PRODUCTION:
-                price = (price - markup_production) * vat_factor
+                if self.price_settings.get("production_price_include_vat", True):
+                    price = (price - markup_production) * vat_factor
+                else:
+                    price = price - markup_production
             else:
                 _LOGGER.error("Unknown source_type: %s", self.source_type)
                 return
@@ -555,7 +558,10 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
             if self.source_type == SOURCE_TYPE_CONSUMPTION:
                 price = (base_price + markup_consumption + tax) * vat_factor
             elif self.source_type == SOURCE_TYPE_PRODUCTION:
-                price = (base_price - markup_production) * vat_factor
+                if self.price_settings.get("production_price_include_vat", True):
+                    price = (base_price - markup_production) * vat_factor
+                else:
+                    price = base_price - markup_production
             else:
                 return
 

--- a/custom_components/dynamic_energy_calculator/strings.json
+++ b/custom_components/dynamic_energy_calculator/strings.json
@@ -20,6 +20,7 @@
           "price_sensor_gas": "Gas price sensor",
           "electricity_consumption_markup_per_kwh": "Electricity consumption markup per kWh",
           "electricity_production_markup_per_kwh": "Electricity production markup per kWh",
+          "production_price_include_vat": "Apply VAT to production price",
           "electricity_surcharge_per_kwh": "Electricity surcharge per kWh",
           "vat_percentage": "VAT percentage",
           "electricity_surcharge_per_day": "Electricity surcharge per day",

--- a/custom_components/dynamic_energy_calculator/translations/en.json
+++ b/custom_components/dynamic_energy_calculator/translations/en.json
@@ -20,6 +20,7 @@
           "price_sensor_gas": "Gas price sensor",
           "electricity_consumption_markup_per_kwh": "Electricity consumption markup per kWh",
           "electricity_production_markup_per_kwh": "Electricity production markup per kWh",
+          "production_price_include_vat": "Apply VAT to production price",
           "electricity_surcharge_per_kwh": "Electricity surcharge per kWh",
           "vat_percentage": "VAT percentage",
           "electricity_surcharge_per_day": "Electricity surcharge per day",

--- a/custom_components/dynamic_energy_calculator/translations/nl.json
+++ b/custom_components/dynamic_energy_calculator/translations/nl.json
@@ -20,6 +20,7 @@
           "price_sensor_gas": "Gas price sensor",
           "electricity_consumption_markup_per_kwh": "Electricity consumption markup per kWh",
           "electricity_production_markup_per_kwh": "Electricity production markup per kWh",
+          "production_price_include_vat": "BTW toepassen op terugleverprijs",
           "electricity_surcharge_per_kwh": "Electricity surcharge per kWh",
           "vat_percentage": "VAT percentage",
           "electricity_surcharge_per_day": "Electricity surcharge per day",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -259,3 +259,26 @@ async def test_production_sensor_cost_and_profit(hass: HomeAssistant):
     await profit_sensor_neg.async_update()
     assert cost_sensor_neg.native_value == pytest.approx(0.2)
     assert profit_sensor_neg.native_value == pytest.approx(0.0)
+
+
+async def test_production_price_no_vat(hass: HomeAssistant):
+    price_settings = {
+        "electricity_production_markup_per_kwh": 0.0,
+        "vat_percentage": 21.0,
+        "production_price_include_vat": False,
+    }
+
+    sensor = CurrentElectricityPriceSensor(
+        hass,
+        "Prod Price",
+        "pp3",
+        price_sensor="sensor.price",
+        source_type=SOURCE_TYPE_PRODUCTION,
+        price_settings=price_settings,
+        icon="mdi:flash",
+        device=DeviceInfo(identifiers={("dec", "test")}),
+    )
+
+    hass.states.async_set("sensor.price", 1.0)
+    await sensor.async_update()
+    assert sensor.native_value == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- add `production_price_include_vat` to price settings
- show boolean selector in config and options flow
- adjust sensors to skip VAT on production prices when disabled
- document new option in translations
- test disabling VAT for production price

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cb8bff1608323ade051b5e804def0