### PR TITLE
Enable diagnostics and add coverage

### DIFF
--- a/custom_components/dynamic_energy_calculator/diagnostics.py
+++ b/custom_components/dynamic_energy_calculator/diagnostics.py
@@ -10,8 +10,8 @@ from homeassistant.core import HomeAssistant
 
 from .const import CONF_CONFIGS, CONF_SOURCES
 
-
 REDACT_CONFIG = set()
+REDACT_STATE = {"context"}
 
 
 async def async_get_config_entry_diagnostics(
@@ -30,11 +30,13 @@ async def async_get_config_entry_diagnostics(
     for block in entry.data.get(CONF_CONFIGS, []):
         for source in block.get(CONF_SOURCES, []):
             state = hass.states.get(source)
+            state_dict = None
+            if state:
+                state_dict = async_redact_data(state.as_dict(), REDACT_STATE)
             data["sources"].append(
                 {
                     "entity_id": source,
-                    "state": state.state if state else None,
-                    "attributes": dict(state.attributes) if state else {},
+                    "state": state_dict,
                 }
             )
 

--- a/custom_components/dynamic_energy_calculator/manifest.json
+++ b/custom_components/dynamic_energy_calculator/manifest.json
@@ -9,6 +9,7 @@
   "iot_class": "calculated",
   "translation_key": "dynamic_energy_calculator",
   "issue_tracker": "https://github.com/bvweerd/dynamic_energy_calculator/issues",
+  "diagnostics": true,
   "quality_scale": "silver",
   "requirements": [],
   "ssdp": [],

--- a/custom_components/dynamic_energy_calculator/quality_scale.yaml
+++ b/custom_components/dynamic_energy_calculator/quality_scale.yaml
@@ -52,7 +52,7 @@ rules:
 
   # Gold
   devices: done
-  diagnostics: todo
+  diagnostics: done
   discovery-update-info:
     status: exempt
     comment: |

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,50 @@
+from homeassistant.core import HomeAssistant
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.dynamic_energy_calculator.const import (
+    CONF_CONFIGS,
+    CONF_SOURCE_TYPE,
+    CONF_SOURCES,
+    DOMAIN,
+    SOURCE_TYPE_CONSUMPTION,
+)
+
+
+async def test_diagnostics_redaction_and_structure(hass: HomeAssistant):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_CONFIGS: [
+                {
+                    CONF_SOURCE_TYPE: SOURCE_TYPE_CONSUMPTION,
+                    CONF_SOURCES: ["sensor.energy"],
+                }
+            ]
+        },
+        options={},
+    )
+    entry.add_to_hass(hass)
+    hass.states.async_set("sensor.energy", 1, {"attr": "val"})
+
+    calls = []
+
+    def _redact(data, to_redact):
+        calls.append((data, to_redact))
+        return data
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "custom_components.dynamic_energy_calculator.diagnostics.async_redact_data",
+            _redact,
+        )
+        from custom_components.dynamic_energy_calculator import diagnostics
+
+        result = await diagnostics.async_get_config_entry_diagnostics(hass, entry)
+
+    assert len(calls) == 3
+    assert result["entry"]["data"] == entry.data
+    assert result["entry"]["options"] == entry.options
+    assert result["sources"][0]["entity_id"] == "sensor.energy"
+    assert result["sources"][0]["state"]["state"] == "1"
+    assert result["sources"][0]["state"]["attributes"] == {"attr": "val"}


### PR DESCRIPTION
## Summary
- enable diagnostics flag in manifest
- redact entity state data in diagnostics output
- add diagnostics tests verifying data redaction
- mark diagnostics requirement complete in quality_scale.yaml

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cc890e5088323bc09696f86172483