### PR TITLE
Add sensor translation keys

### DIFF
--- a/custom_components/dynamic_energy_calculator/quality_scale.yaml
+++ b/custom_components/dynamic_energy_calculator/quality_scale.yaml
@@ -75,9 +75,9 @@ rules:
   entity-category: todo
   entity-device-class: done
   entity-disabled-by-default: done
-  entity-translations: todo
-  exception-translations: todo
-  icon-translations: todo
+  entity-translations: done
+  exception-translations: done
+  icon-translations: done
   reconfiguration-flow: done
   repair-issues: todo
   stale-devices:

--- a/custom_components/dynamic_energy_calculator/translations/en.json
+++ b/custom_components/dynamic_energy_calculator/translations/en.json
@@ -65,5 +65,29 @@
         }
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "kwh_total": {"name": "Total kWh", "icon": "mdi:counter"},
+      "cost_total": {"name": "Total Cost", "icon": "mdi:cash"},
+      "profit_total": {"name": "Total Profit", "icon": "mdi:cash-plus"},
+      "kwh_during_cost_total": {"name": "kWh During Cost", "icon": "mdi:transmission-tower-export"},
+      "kwh_during_profit_total": {"name": "kWh During Profit", "icon": "mdi:transmission-tower-import"},
+      "m3_total": {"name": "Total m³", "icon": "mdi:counter"},
+      "daily_electricity_cost_total": {"name": "Electricity Contract Fixed Costs (Total)", "icon": "mdi:calendar-currency"},
+      "daily_gas_cost_total": {"name": "Gas Contract Fixed Costs (Total)", "icon": "mdi:calendar-currency"},
+      "net_total_cost": {"name": "Net Energy Cost (Total)", "icon": "mdi:scale-balance"},
+      "total_energy_cost": {"name": "Energy Contract Cost (Total)", "icon": "mdi:currency-eur"},
+      "current_consumption_price": {"name": "Current Consumption Price", "icon": "mdi:transmission-tower-import"},
+      "current_production_price": {"name": "Current Production Price", "icon": "mdi:transmission-tower-export"},
+      "current_gas_consumption_price": {"name": "Current Gas Consumption Price", "icon": "mdi:gas-burner"}
+    }
+  },
+  "exception": {
+    "energy_source_unavailable": "Energy source %s is unavailable",
+    "energy_source_invalid": "Energy source %s has invalid state",
+    "price_sensor_unavailable": "Price sensor %s is unavailable",
+    "price_sensor_invalid": "Price sensor %s has invalid state",
+    "unknown_source_type": "Unknown source_type: %s"
   }
 }

--- a/custom_components/dynamic_energy_calculator/translations/nl.json
+++ b/custom_components/dynamic_energy_calculator/translations/nl.json
@@ -65,5 +65,29 @@
         }
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "kwh_total": {"name": "Total kWh", "icon": "mdi:counter"},
+      "cost_total": {"name": "Total Cost", "icon": "mdi:cash"},
+      "profit_total": {"name": "Total Profit", "icon": "mdi:cash-plus"},
+      "kwh_during_cost_total": {"name": "kWh During Cost", "icon": "mdi:transmission-tower-export"},
+      "kwh_during_profit_total": {"name": "kWh During Profit", "icon": "mdi:transmission-tower-import"},
+      "m3_total": {"name": "Total m³", "icon": "mdi:counter"},
+      "daily_electricity_cost_total": {"name": "Electricity Contract Fixed Costs (Total)", "icon": "mdi:calendar-currency"},
+      "daily_gas_cost_total": {"name": "Gas Contract Fixed Costs (Total)", "icon": "mdi:calendar-currency"},
+      "net_total_cost": {"name": "Net Energy Cost (Total)", "icon": "mdi:scale-balance"},
+      "total_energy_cost": {"name": "Energy Contract Cost (Total)", "icon": "mdi:currency-eur"},
+      "current_consumption_price": {"name": "Current Consumption Price", "icon": "mdi:transmission-tower-import"},
+      "current_production_price": {"name": "Current Production Price", "icon": "mdi:transmission-tower-export"},
+      "current_gas_consumption_price": {"name": "Current Gas Consumption Price", "icon": "mdi:gas-burner"}
+    }
+  },
+  "exception": {
+    "energy_source_unavailable": "Energy source %s is unavailable",
+    "energy_source_invalid": "Energy source %s has invalid state",
+    "price_sensor_unavailable": "Price sensor %s is unavailable",
+    "price_sensor_invalid": "Price sensor %s has invalid state",
+    "unknown_source_type": "Unknown source_type: %s"
   }
 }


### PR DESCRIPTION
## Summary
- add translation_key support for sensors
- move sensor names and icons to translations
- provide error message translations
- mark translation rules complete in quality scale

## Testing
- `pre-commit run --files custom_components/dynamic_energy_calculator/sensor.py custom_components/dynamic_energy_calculator/translations/en.json custom_components/dynamic_energy_calculator/translations/nl.json custom_components/dynamic_energy_calculator/quality_scale.yaml`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cc8991034832393b3bae7bd3bb386