### PR TITLE
Set state class for utility sensors

### DIFF
--- a/custom_components/dynamic_energy_calculator/sensor.py
+++ b/custom_components/dynamic_energy_calculator/sensor.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from homeassistant.components.sensor import SensorEntity, RestoreEntity
+from homeassistant.components.sensor import (
+    SensorEntity,
+    RestoreEntity,
+    SensorStateClass,
+)
 from homeassistant.const import UnitOfEnergy, UnitOfVolume
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -118,7 +122,7 @@ class BaseUtilitySensor(SensorEntity, RestoreEntity):
         self._attr_unique_id = unique_id
         self._attr_native_unit_of_measurement = unit
         self._attr_device_class = device_class
-        self._attr_state_class = "total"
+        self._attr_state_class = SensorStateClass.TOTAL
         self._attr_native_value = 0.0
         self._attr_available = True
         self._attr_icon = icon
@@ -239,6 +243,8 @@ class DynamicEnergySensor(BaseUtilitySensor):
             device=device,
             translation_key=mode,
         )
+        if mode in ("kwh_total", "m3_total"):
+            self._attr_state_class = SensorStateClass.TOTAL_INCREASING
         self.hass = hass
         self.energy_sensor = energy_sensor
         self.input_sensors = [energy_sensor]
@@ -654,6 +660,7 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
             device=device,
             translation_key=name.lower().replace(" ", "_"),
         )
+        self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self.hass = hass
         self.price_sensor = price_sensor

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,6 +1,6 @@
 import pytest
 from homeassistant.core import HomeAssistant
-from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import UnitOfEnergy, UnitOfVolume
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 
@@ -174,6 +174,32 @@ async def test_current_electricity_price(hass: HomeAssistant):
         device=DeviceInfo(identifiers={("dec", "test")}),
     )
     assert sensor.native_unit_of_measurement == "€/kWh"
+    assert sensor.state_class == SensorStateClass.MEASUREMENT
+
+
+async def test_dynamic_energy_sensor_state_class(hass: HomeAssistant):
+    sensor_kwh = DynamicEnergySensor(
+        hass,
+        "Energy",
+        "eidkwh",
+        "sensor.energy",
+        SOURCE_TYPE_CONSUMPTION,
+        {},
+        mode="kwh_total",
+    )
+    assert sensor_kwh.state_class == SensorStateClass.TOTAL_INCREASING
+
+    sensor_m3 = DynamicEnergySensor(
+        hass,
+        "Gas",
+        "eidgas",
+        "sensor.gas",
+        SOURCE_TYPE_GAS,
+        {},
+        mode="m3_total",
+        unit=UnitOfVolume.CUBIC_METERS,
+    )
+    assert sensor_m3.state_class == SensorStateClass.TOTAL_INCREASING
 
 
 async def test_total_energy_cost_multiple(hass: HomeAssistant):
@@ -285,6 +311,7 @@ async def test_production_price_no_vat(hass: HomeAssistant):
     await sensor.async_update()
     assert sensor.native_value == pytest.approx(1.0)
 
+
 async def test_missing_price_sensor_issue_called(hass: HomeAssistant):
     price_settings = {}
     sensor = DynamicEnergySensor(
@@ -301,9 +328,11 @@ async def test_missing_price_sensor_issue_called(hass: HomeAssistant):
     hass.states.async_set("sensor.energy", 1)
     called = {}
     with pytest.MonkeyPatch.context() as mp:
+
         def fake_issue(hass_arg, issue_id, translation_key, placeholders=None):
             called["issue_id"] = issue_id
             called["key"] = translation_key
+
         mp.setattr(
             "custom_components.dynamic_energy_calculator.sensor.async_report_issue",
             fake_issue,


### PR DESCRIPTION
## Summary
- use `SensorStateClass` enum rather than raw strings
- mark cumulative energy sensors as `TOTAL_INCREASING`
- mark current price sensors as `MEASUREMENT`
- test state class values

## Testing
- `pre-commit run --files custom_components/dynamic_energy_calculator/sensor.py tests/test_sensor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cdf3c1cbc8323ac949b3db2884c41