### PR TITLE
Move service registration to setup

### DIFF
--- a/custom_components/dynamic_energy_calculator/__init__.py
+++ b/custom_components/dynamic_energy_calculator/__init__.py
@@ -6,6 +6,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 
 from .const import DOMAIN, PLATFORMS
+from .services import async_register_services, async_unregister_services
 
 import logging
 
@@ -15,6 +16,9 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the base integration (no YAML)."""
     hass.data.setdefault(DOMAIN, {})
+    if not hass.data[DOMAIN].get("services_registered"):
+        await async_register_services(hass)
+        hass.data[DOMAIN]["services_registered"] = True
     _LOGGER.info("Initialized Dynamic Energy Contract Calculator")
     return True
 
@@ -40,6 +44,14 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
         _LOGGER.debug("Successfully unloaded entry %s", entry.entry_id)
+        remaining = [
+            k
+            for k in hass.data[DOMAIN]
+            if k not in ("services_registered", "entities")
+        ]
+        if not remaining and hass.data[DOMAIN].get("services_registered"):
+            await async_unregister_services(hass)
+            hass.data[DOMAIN]["services_registered"] = False
     else:
         _LOGGER.warning("Failed to unload entry %s", entry.entry_id)
     return unload_ok

--- a/custom_components/dynamic_energy_calculator/sensor.py
+++ b/custom_components/dynamic_energy_calculator/sensor.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from homeassistant.components.sensor import SensorEntity, RestoreEntity
 from homeassistant.const import UnitOfEnergy, UnitOfVolume
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import (
     async_track_state_change_event,
@@ -872,26 +872,5 @@ async def async_setup_entry(
         )
 
     async_add_entities(entities, True)
-
-    async def handle_reset_all(call: ServiceCall):
-        for ent in entities:
-            ent.reset()
-
-    async def handle_reset_selected(call: ServiceCall):
-        ids = call.data.get("entity_ids", [])
-        for ent in entities:
-            if ent.entity_id in ids:
-                ent.reset()
-
-    async def handle_set_value(call: ServiceCall):
-        entity_id = call.data.get("entity_id")
-        value = call.data.get("value", 0.0)
-        for ent in entities:
-            if ent.entity_id == entity_id:
-                ent.set_value(value)
-
-    hass.services.async_register(DOMAIN, "reset_all_meters", handle_reset_all)
-    hass.services.async_register(DOMAIN, "reset_selected_meters", handle_reset_selected)
-    hass.services.async_register(DOMAIN, "set_meter_value", handle_set_value)
 
     hass.data[DOMAIN]["entities"] = entities

--- a/custom_components/dynamic_energy_calculator/services.py
+++ b/custom_components/dynamic_energy_calculator/services.py
@@ -45,6 +45,14 @@ async def async_register_services(hass: HomeAssistant) -> None:
     _LOGGER.debug("Dynamic Energy Contract Calculator services registered.")
 
 
+async def async_unregister_services(hass: HomeAssistant) -> None:
+    """Remove custom services when no entries remain."""
+    hass.services.async_remove(DOMAIN, "reset_all_meters")
+    hass.services.async_remove(DOMAIN, "reset_selected_meters")
+    hass.services.async_remove(DOMAIN, "set_meter_value")
+    _LOGGER.debug("Dynamic Energy Contract Calculator services unregistered.")
+
+
 # ─── service handlers ─────────────────────────────────────────────────────────
 
 

--- a/tests/test_sensor_setup.py
+++ b/tests/test_sensor_setup.py
@@ -1,3 +1,4 @@
+import pytest
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.dynamic_energy_calculator.sensor import async_setup_entry
@@ -16,6 +17,7 @@ async def test_async_setup_entry(hass: HomeAssistant):
     from custom_components.dynamic_energy_calculator import async_setup
 
     await async_setup(hass, {})
+    assert hass.services.has_service(DOMAIN, "reset_all_meters")
     hass.states.async_set("sensor.energy", 0)
     hass.states.async_set("sensor.price", 0)
     entry = MockConfigEntry(


### PR DESCRIPTION
## Summary
- register services in `async_setup`
- unregister services when last entry is unloaded
- remove service registration from `sensor.py`
- update tests for new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cdf3a25d08323b5fa54c2a9ff413a