### PR TITLE
Prevent second config entry

### DIFF
--- a/custom_components/dynamic_energy_calculator/config_flow.py
+++ b/custom_components/dynamic_energy_calculator/config_flow.py
@@ -29,6 +29,8 @@ class DynamicEnergyCalculatorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN
     VERSION = 1
 
     def __init__(self) -> None:
+        super().__init__()
+        self.context = {}
         self.configs: list[dict] = []
         self.source_type: str | None = None
         self.sources: list[str] | None = None
@@ -37,6 +39,9 @@ class DynamicEnergyCalculatorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN
     async def async_step_user(
         self, user_input: dict[str, str] | None = None
     ) -> FlowResult:
+        await self.async_set_unique_id(DOMAIN)
+        if self._async_current_entries():
+            return self.async_abort(reason="already_configured")
         if user_input is not None:
             choice = user_input[CONF_SOURCE_TYPE]
             if choice == "finish":

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,8 +8,10 @@ from custom_components.dynamic_energy_calculator.const import (
     CONF_CONFIGS,
     CONF_SOURCE_TYPE,
     CONF_SOURCES,
+    DOMAIN,
     SOURCE_TYPE_CONSUMPTION,
 )
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 
 async def test_flow_no_blocks(hass: HomeAssistant):
@@ -41,3 +43,15 @@ async def test_full_flow(hass: HomeAssistant):
     assert result["data"][CONF_CONFIGS] == [
         {CONF_SOURCE_TYPE: SOURCE_TYPE_CONSUMPTION, CONF_SOURCES: ["sensor.energy"]}
     ]
+
+
+async def test_single_instance_abort(hass: HomeAssistant):
+    flow = DynamicEnergyCalculatorConfigFlow()
+    flow.hass = hass
+
+    entry = MockConfigEntry(domain=DOMAIN, data={}, entry_id="1")
+    entry.add_to_hass(hass)
+
+    result = await flow.async_step_user()
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"


### PR DESCRIPTION
## Summary
- ensure `async_step_user` sets unique ID and aborts when already configured
- test second entry aborts

## Testing
- `pre-commit run --files custom_components/dynamic_energy_calculator/config_flow.py tests/test_config_flow.py`
- `pytest -q tests/test_config_flow.py`

------
https://chatgpt.com/codex/tasks/task_e_687cdf381fdc8323b3f711b3386a0173