### PR TITLE
Remove diagnostic category from summary sensors

### DIFF
--- a/custom_components/dynamic_energy_calculator/sensor.py
+++ b/custom_components/dynamic_energy_calculator/sensor.py
@@ -175,7 +175,6 @@ class TotalCostSensor(BaseUtilitySensor):
             device=device,
             translation_key="net_total_cost",
         )
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self.hass = hass
 
     async def async_update(self):
@@ -455,7 +454,6 @@ class DailyElectricityCostSensor(BaseUtilitySensor):
             device=device,
             translation_key="daily_electricity_cost_total",
         )
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self.hass = hass
         self.price_settings = price_settings
 
@@ -523,7 +521,6 @@ class DailyGasCostSensor(BaseUtilitySensor):
             device=device,
             translation_key="daily_gas_cost_total",
         )
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self.hass = hass
         self.price_settings = price_settings
 
@@ -586,7 +583,6 @@ class TotalEnergyCostSensor(BaseUtilitySensor):
             device=device,
             translation_key="total_energy_cost",
         )
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self.hass = hass
         self.net_cost_entity_id = net_cost_entity_id
         self.fixed_cost_entity_ids = fixed_cost_entity_ids
@@ -661,7 +657,6 @@ class CurrentElectricityPriceSensor(BaseUtilitySensor):
             translation_key=name.lower().replace(" ", "_"),
         )
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self.hass = hass
         self.price_sensor = price_sensor
         self.source_type = source_type

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -122,7 +122,7 @@ async def test_daily_gas_cost_sensor(hass: HomeAssistant):
         {"gas_standing_charge_per_day": 0.5, "vat_percentage": 0.0},
         DeviceInfo(identifiers={("dec", "test")}),
     )
-    assert sensor.entity_category is EntityCategory.DIAGNOSTIC
+    assert sensor.entity_category is None
     assert sensor._calculate_daily_cost() == pytest.approx(0.5)
 
 
@@ -139,7 +139,7 @@ async def test_daily_electricity_cost_sensor(hass: HomeAssistant):
         },
         DeviceInfo(identifiers={("dec", "test")}),
     )
-    assert sensor.entity_category is EntityCategory.DIAGNOSTIC
+    assert sensor.entity_category is None
     assert sensor._calculate_daily_cost() == pytest.approx(0.6)
 
 


### PR DESCRIPTION
## Summary
- make summary sensors regular sensors instead of diagnostics
- adjust tests to expect `None` entity category

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce3151eb08323b569f170949d05fb