### PR TITLE
Fix reset service

### DIFF
--- a/custom_components/dynamic_energy_calculator/services.py
+++ b/custom_components/dynamic_energy_calculator/services.py
@@ -59,10 +59,10 @@ async def async_unregister_services(hass: HomeAssistant) -> None:
 async def _handle_reset_all(call: ServiceCall) -> None:
     """Reset **all** dynamic‐energy sensors back to zero."""
     _LOGGER.info("Service reset_all_meters called")
-    for entity in call.hass.states.async_entity_ids(f"{DOMAIN}."):
-        ent = call.hass.data[DOMAIN]["entities"].get(entity)
-        if ent and hasattr(ent, "async_reset"):
-            _LOGGER.debug("  resetting %s", entity)
+    entities = call.hass.data.get(DOMAIN, {}).get("entities", {})
+    for entity_id, ent in entities.items():
+        if hasattr(ent, "async_reset"):
+            _LOGGER.debug("  resetting %s", entity_id)
             await ent.async_reset()
 
 

--- a/custom_components/dynamic_energy_calculator/services.yaml
+++ b/custom_components/dynamic_energy_calculator/services.yaml
@@ -11,6 +11,11 @@ reset_selected_meters:
       description: List of sensor entity_ids to reset.
       required: true
       example: ["sensor.dynamic_energy_calculator_kwh_total"]
+      selector:
+        entity:
+          domain: sensor
+          integration: dynamic_energy_calculator
+          multiple: true
 
 set_meter_value:
   name: Set meter value
@@ -21,8 +26,17 @@ set_meter_value:
       description: The entity_id of the sensor.
       required: true
       example: "sensor.dynamic_energy_calculator_kwh_total"
+      selector:
+        entity:
+          domain: sensor
+          integration: dynamic_energy_calculator
     value:
       name: Value
       description: The new value for the sensor.
       required: true
       example: 123.45
+      selector:
+        number:
+          min: 0
+          mode: box
+          step: 0.01

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -44,16 +44,6 @@ async def test_service_handlers(hass: HomeAssistant):
     hass.data[DOMAIN] = {"entities": {"dynamic_energy_calculator.test": Dummy()}}
     hass.states.async_set("dynamic_energy_calculator.test", 1)
 
-    def ids(prefix=None):
-        if prefix == f"{DOMAIN}.":
-            return ["dynamic_energy_calculator.test"]
-        return []
-
-    monkeypatch = pytest.MonkeyPatch()
-    monkeypatch.setattr(
-        hass.states.__class__, "async_entity_ids", lambda self, prefix=None: ids(prefix)
-    )
-
     await _handle_reset_all(ServiceCall(hass, DOMAIN, "reset_all_meters", {}))
     assert called["reset"]
 


### PR DESCRIPTION
## Summary
- fix `reset_all_meters` service to actually reset all sensors
- improve service UI by adding selectors for the sensor and value fields
- adapt tests to new implementation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf1a94fd883238441b731d428edd6