### PR TITLE
Reload sensors when options update

### DIFF
--- a/custom_components/dynamic_energy_calculator/__init__.py
+++ b/custom_components/dynamic_energy_calculator/__init__.py
@@ -34,11 +34,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Store entry data
     hass.data[DOMAIN][entry.entry_id] = entry.data
 
+    entry.async_on_unload(entry.add_update_listener(_update_listener))
+
     # Forward entry to ALL our platforms in one call:
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     _LOGGER.debug("Forwarded entry %s to platforms %s", entry.entry_id, PLATFORMS)
     return True
+
+
+async def _update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update by reloading the config entry."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:


### PR DESCRIPTION
## Summary
- reload entry when options are saved so updated price settings apply immediately

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf8d5e6588323936c7840129ceaf7