### PR TITLE
Fix options flow labels

### DIFF
--- a/custom_components/dynamic_energy_calculator/strings.json
+++ b/custom_components/dynamic_energy_calculator/strings.json
@@ -36,6 +36,43 @@
       "no_blocks": "You must add at least one configuration block."
     }
   },
+  "options": {
+    "step": {
+      "user": {
+        "title": "Dynamic Energy Contract Calculator",
+        "data": {
+          "source_type": "Source type"
+        }
+      },
+      "select_sources": {
+        "title": "Select sources",
+        "data": {
+          "sources": "Energy sensors"
+        }
+      },
+      "price_settings": {
+        "title": "Price settings",
+        "data": {
+          "price_sensor": "Electricity price sensor",
+          "price_sensor_gas": "Gas price sensor",
+          "electricity_consumption_markup_per_kwh": "Electricity consumption markup per kWh",
+          "electricity_production_markup_per_kwh": "Electricity production markup per kWh",
+          "production_price_include_vat": "Apply VAT to production price",
+          "electricity_surcharge_per_kwh": "Electricity surcharge per kWh",
+          "vat_percentage": "VAT percentage",
+          "electricity_surcharge_per_day": "Electricity surcharge per day",
+          "electricity_standing_charge_per_day": "Electricity standing charge per day",
+          "electricity_tax_rebate_per_day": "Electricity tax rebate per day",
+          "gas_markup_per_m3": "Gas markup per m³",
+          "gas_surcharge_per_m3": "Gas surcharge per m³",
+          "gas_standing_charge_per_day": "Gas standing charge per day"
+        }
+      }
+    },
+    "error": {
+      "no_blocks": "You must add at least one configuration block."
+    }
+  },
   "services": {
     "reset_all_meters": {
       "name": "Reset all meters",

--- a/custom_components/dynamic_energy_calculator/translations/en.json
+++ b/custom_components/dynamic_energy_calculator/translations/en.json
@@ -36,6 +36,43 @@
       "no_blocks": "You must add at least one configuration block."
     }
   },
+  "options": {
+    "step": {
+      "user": {
+        "title": "Dynamic Energy Contract Calculator",
+        "data": {
+          "source_type": "Source type"
+        }
+      },
+      "select_sources": {
+        "title": "Select sources",
+        "data": {
+          "sources": "Energy sensors"
+        }
+      },
+      "price_settings": {
+        "title": "Price settings",
+        "data": {
+          "price_sensor": "Electricity price sensor",
+          "price_sensor_gas": "Gas price sensor",
+          "electricity_consumption_markup_per_kwh": "Electricity consumption markup per kWh",
+          "electricity_production_markup_per_kwh": "Electricity production markup per kWh",
+          "production_price_include_vat": "Apply VAT to production price",
+          "electricity_surcharge_per_kwh": "Electricity surcharge per kWh",
+          "vat_percentage": "VAT percentage",
+          "electricity_surcharge_per_day": "Electricity surcharge per day",
+          "electricity_standing_charge_per_day": "Electricity standing charge per day",
+          "electricity_tax_rebate_per_day": "Electricity tax rebate per day",
+          "gas_markup_per_m3": "Gas markup per m³",
+          "gas_surcharge_per_m3": "Gas surcharge per m³",
+          "gas_standing_charge_per_day": "Gas standing charge per day"
+        }
+      }
+    },
+    "error": {
+      "no_blocks": "You must add at least one configuration block."
+    }
+  },
   "services": {
     "reset_all_meters": {
       "name": "Reset all meters",

--- a/custom_components/dynamic_energy_calculator/translations/nl.json
+++ b/custom_components/dynamic_energy_calculator/translations/nl.json
@@ -36,6 +36,43 @@
       "no_blocks": "You must add at least one configuration block."
     }
   },
+  "options": {
+    "step": {
+      "user": {
+        "title": "Dynamic Energy Contract Calculator",
+        "data": {
+          "source_type": "Source type"
+        }
+      },
+      "select_sources": {
+        "title": "Select sources",
+        "data": {
+          "sources": "Energy sensors"
+        }
+      },
+      "price_settings": {
+        "title": "Price settings",
+        "data": {
+          "price_sensor": "Electricity price sensor",
+          "price_sensor_gas": "Gas price sensor",
+          "electricity_consumption_markup_per_kwh": "Electricity consumption markup per kWh",
+          "electricity_production_markup_per_kwh": "Electricity production markup per kWh",
+          "production_price_include_vat": "BTW toepassen op terugleverprijs",
+          "electricity_surcharge_per_kwh": "Electricity surcharge per kWh",
+          "vat_percentage": "VAT percentage",
+          "electricity_surcharge_per_day": "Electricity surcharge per day",
+          "electricity_standing_charge_per_day": "Electricity standing charge per day",
+          "electricity_tax_rebate_per_day": "Electricity tax rebate per day",
+          "gas_markup_per_m3": "Gas markup per m³",
+          "gas_surcharge_per_m3": "Gas surcharge per m³",
+          "gas_standing_charge_per_day": "Gas standing charge per day"
+        }
+      }
+    },
+    "error": {
+      "no_blocks": "You must add at least one configuration block."
+    }
+  },
   "services": {
     "reset_all_meters": {
       "name": "Reset all meters",


### PR DESCRIPTION
## Summary
- include options flow labels in strings.json
- add translations for options flow in English and Dutch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf919740c8323a6b2630d804737e9