### PR TITLE
Fix options flow labels

### DIFF
--- a/custom_components/dynamic_energy_calculator/config_flow.py
+++ b/custom_components/dynamic_energy_calculator/config_flow.py
@@ -47,7 +47,7 @@ class DynamicEnergyCalculatorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN
             if choice == "finish":
                 if not self.configs:
                     return self.async_show_form(
-                        step_id="user",
+                        step_id="init",
                         data_schema=self._schema_user(),
                         errors={"base": "no_blocks"},
                     )
@@ -68,7 +68,7 @@ class DynamicEnergyCalculatorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN
             self.source_type = choice
             return await self.async_step_select_sources()
 
-        return self.async_show_form(step_id="user", data_schema=self._schema_user())
+        return self.async_show_form(step_id="init", data_schema=self._schema_user())
 
     def _schema_user(self) -> vol.Schema:
         options = [{"value": t, "label": t.title()} for t in SOURCE_TYPES]
@@ -224,7 +224,7 @@ class DynamicEnergyCalculatorOptionsFlowHandler(config_entries.OptionsFlow):
             if choice == "finish":
                 if not self.configs:
                     return self.async_show_form(
-                        step_id="user",
+                        step_id="init",
                         data_schema=self._schema_user(),
                         errors={"base": "no_blocks"},
                     )
@@ -244,7 +244,7 @@ class DynamicEnergyCalculatorOptionsFlowHandler(config_entries.OptionsFlow):
             self.source_type = choice
             return await self.async_step_select_sources()
 
-        return self.async_show_form(step_id="user", data_schema=self._schema_user())
+        return self.async_show_form(step_id="init", data_schema=self._schema_user())
 
     def _schema_user(self) -> vol.Schema:
         options = [{"value": t, "label": t.title()} for t in SOURCE_TYPES]

--- a/custom_components/dynamic_energy_calculator/strings.json
+++ b/custom_components/dynamic_energy_calculator/strings.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "step": {
-      "user": {
+      "init": {
         "title": "Dynamic Energy Contract Calculator",
         "data": {
           "source_type": "Source type"
@@ -38,7 +38,7 @@
   },
   "options": {
     "step": {
-      "user": {
+      "init": {
         "title": "Dynamic Energy Contract Calculator",
         "data": {
           "source_type": "Source type"

--- a/custom_components/dynamic_energy_calculator/translations/en.json
+++ b/custom_components/dynamic_energy_calculator/translations/en.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "step": {
-      "user": {
+      "init": {
         "title": "Dynamic Energy Contract Calculator",
         "data": {
           "source_type": "Source type"
@@ -38,7 +38,7 @@
   },
   "options": {
     "step": {
-      "user": {
+      "init": {
         "title": "Dynamic Energy Contract Calculator",
         "data": {
           "source_type": "Source type"

--- a/custom_components/dynamic_energy_calculator/translations/nl.json
+++ b/custom_components/dynamic_energy_calculator/translations/nl.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "step": {
-      "user": {
+      "init": {
         "title": "Dynamic Energy Contract Calculator",
         "data": {
           "source_type": "Source type"
@@ -38,7 +38,7 @@
   },
   "options": {
     "step": {
-      "user": {
+      "init": {
         "title": "Dynamic Energy Contract Calculator",
         "data": {
           "source_type": "Source type"


### PR DESCRIPTION
## Summary
- use the `init` step for the options flow
- update translation keys for the new step

## Testing
- `pre-commit run --files custom_components/dynamic_energy_calculator/config_flow.py custom_components/dynamic_energy_calculator/strings.json custom_components/dynamic_energy_calculator/translations/en.json custom_components/dynamic_energy_calculator/translations/nl.json`
- `pytest -k options_flow -vv`

------
https://chatgpt.com/codex/tasks/task_e_687cfc89e47083238eff9ff65a9682e1