### PR TITLE
Improve test coverage

### DIFF
--- a/tests/test_entity_extra.py
+++ b/tests/test_entity_extra.py
@@ -1,0 +1,148 @@
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+
+from custom_components.dynamic_energy_calculator.entity import DynamicEnergySensor
+from custom_components.dynamic_energy_calculator.const import (
+    SOURCE_TYPE_CONSUMPTION,
+    SOURCE_TYPE_PRODUCTION,
+    SOURCE_TYPE_GAS,
+)
+
+
+async def _make_sensor(hass: HomeAssistant, **kwargs) -> DynamicEnergySensor:
+    defaults = dict(
+        name="Test",
+        unique_id="uid",
+        energy_sensor="sensor.energy",
+        source_type=SOURCE_TYPE_CONSUMPTION,
+        price_settings={},
+        price_sensor="sensor.price",
+        mode="cost_total",
+    )
+    defaults.update(kwargs)
+    sensor = DynamicEnergySensor(hass, **defaults)
+    return sensor
+
+
+async def test_energy_unavailable(hass: HomeAssistant):
+    sensor = await _make_sensor(hass)
+    called = {}
+    with pytest.MonkeyPatch.context() as mp:
+        def issue(hass_arg, issue_id, translation_key, placeholders=None):
+            called['key'] = translation_key
+        mp.setattr(
+            "custom_components.dynamic_energy_calculator.entity.async_report_issue",
+            issue,
+        )
+        await sensor.async_update()
+    assert called['key'] == "energy_source_unavailable"
+    assert not sensor.available
+
+
+async def test_energy_invalid(hass: HomeAssistant):
+    sensor = await _make_sensor(hass)
+    hass.states.async_set("sensor.energy", "bad")
+    called = {}
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "custom_components.dynamic_energy_calculator.entity.async_report_issue",
+            lambda *a, **k: called.update(ok=True),
+        )
+        await sensor.async_update()
+    assert called.get("ok")
+    assert not sensor.available
+
+
+async def test_delta_negative(hass: HomeAssistant):
+    sensor = await _make_sensor(hass, mode="kwh_total", price_sensor=None)
+    sensor._last_energy = 5
+    hass.states.async_set("sensor.energy", 4)
+    await sensor.async_update()
+    assert sensor.native_value == 0
+
+
+async def test_missing_price_sensor(hass: HomeAssistant):
+    sensor = await _make_sensor(hass, price_sensor=None)
+    sensor._last_energy = 0
+    hass.states.async_set("sensor.energy", 1)
+    called = {}
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "custom_components.dynamic_energy_calculator.entity.async_report_issue",
+            lambda *a, **k: called.update(missing=True),
+        )
+        await sensor.async_update()
+    assert called.get("missing")
+
+
+async def test_price_unavailable(hass: HomeAssistant):
+    sensor = await _make_sensor(hass)
+    sensor._last_energy = 0
+    hass.states.async_set("sensor.energy", 1)
+    # price sensor unavailable
+    hass.states.async_set("sensor.price", "unavailable")
+    called = {}
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "custom_components.dynamic_energy_calculator.entity.async_report_issue",
+            lambda *a, **k: called.update(price=True),
+        )
+        await sensor.async_update()
+    assert called.get("price")
+    assert not sensor.available
+
+
+async def test_price_invalid(hass: HomeAssistant):
+    sensor = await _make_sensor(hass)
+    sensor._last_energy = 0
+    hass.states.async_set("sensor.energy", 1)
+    hass.states.async_set("sensor.price", "bad")
+    called = {}
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "custom_components.dynamic_energy_calculator.entity.async_report_issue",
+            lambda *a, **k: called.update(price=True),
+        )
+        await sensor.async_update()
+    assert called.get("price")
+    assert not sensor.available
+
+
+async def test_unknown_source_type(hass: HomeAssistant):
+    sensor = await _make_sensor(hass, source_type="other")
+    sensor._last_energy = 0
+    hass.states.async_set("sensor.energy", 1)
+    hass.states.async_set("sensor.price", 1.0)
+    await sensor.async_update()
+    assert sensor.native_value == 0
+
+
+async def test_handle_input_event(hass: HomeAssistant):
+    sensor = await _make_sensor(hass, mode="kwh_total", price_sensor=None)
+    sensor.async_write_ha_state = lambda *a, **k: None
+    # unavailable state
+    event = type("E", (), {"data": {"new_state": None}})()
+    await sensor._handle_input_event(event)
+    assert not sensor.available
+    # valid state triggers update
+    hass.states.async_set("sensor.energy", 1)
+    updated = {}
+    async def fake_update():
+        updated['u'] = True
+    sensor.async_update = fake_update
+    event = type("E", (), {"data": {"new_state": hass.states.get("sensor.energy")}})()
+    await sensor._handle_input_event(event)
+    assert updated.get('u')
+
+
+async def test_update_listener(hass: HomeAssistant):
+    from custom_components.dynamic_energy_calculator import _update_listener
+    called = {}
+    with pytest.MonkeyPatch.context() as mp:
+        async def reload(entry_id):
+            called['reloaded'] = entry_id
+        mp.setattr(hass.config_entries, "async_reload", reload)
+        entry = type("Entry", (), {"entry_id": "1"})()
+        await _update_listener(hass, entry)
+    assert called.get("reloaded") == "1"

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -39,3 +39,22 @@ async def test_options_flow_full_flow(hass: HomeAssistant):
     assert result["data"][CONF_CONFIGS] == [
         {CONF_SOURCE_TYPE: SOURCE_TYPE_CONSUMPTION, CONF_SOURCES: ["sensor.energy"]}
     ]
+
+async def test_options_flow_price_settings(hass: HomeAssistant):
+    entry = MockConfigEntry(domain="dynamic_energy_calculator", data={}, entry_id="1")
+    flow = DynamicEnergyCalculatorOptionsFlowHandler(entry)
+    flow.hass = hass
+
+    result = await flow.async_step_user({CONF_SOURCE_TYPE: "price_settings"})
+    assert result["type"] == FlowResultType.FORM
+
+    result = await flow.async_step_price_settings({"vat_percentage": 10.0})
+    assert flow.price_settings["vat_percentage"] == 10.0
+    assert result["type"] == FlowResultType.FORM
+
+async def test_options_flow_init_delegates(hass: HomeAssistant):
+    entry = MockConfigEntry(domain="dynamic_energy_calculator", data={}, entry_id="1")
+    flow = DynamicEnergyCalculatorOptionsFlowHandler(entry)
+    flow.hass = hass
+    result = await flow.async_step_init()
+    assert result["type"] == FlowResultType.FORM

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1,0 +1,16 @@
+import pytest
+from homeassistant.core import HomeAssistant
+from custom_components.dynamic_energy_calculator.repair import async_report_issue
+
+
+async def test_async_report_issue_exception_handled(hass: HomeAssistant):
+    def raise_issue(*args, **kwargs):
+        raise Exception("boom")
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "homeassistant.helpers.issue_registry.async_create_issue",
+            raise_issue,
+        )
+        # Should not raise even if create_issue fails
+        async_report_issue(hass, "x", "y", {"a": "b"})


### PR DESCRIPTION
## Summary
- expand sensor, options flow, and repair tests
- add entity edge-case tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d07500e4483239fccabef5c4dbfdf