### PR TITLE
Fix precommit workflow push

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -51,5 +51,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "chore: apply pre-commit fixes" || echo "no changes"
-          git push
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: apply pre-commit fixes"
+            git push
+          fi


### PR DESCRIPTION
## Summary
- ensure pre-commit workflow skips `git push` when there are no changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d1d215c548323a8fd526a7535d09f