### PR TITLE
Fix timezone for Home Assistant tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+@pytest.fixture(autouse=True)
+async def set_time_zone(hass):
+    """Set a valid IANA time zone for Home Assistant tests."""
+    await hass.config.async_set_time_zone("America/Los_Angeles")
+    yield


### PR DESCRIPTION
## Summary
- set timezone to `America/Los_Angeles` for test fixture

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d217a3fb083239a55d940ba804f48