### PR TITLE
Remove unused context assignment

### DIFF
--- a/custom_components/dynamic_energy_calculator/config_flow.py
+++ b/custom_components/dynamic_energy_calculator/config_flow.py
@@ -30,7 +30,6 @@ class DynamicEnergyCalculatorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN
 
     def __init__(self) -> None:
         super().__init__()
-        self.context = {}
         self.configs: list[dict] = []
         self.source_type: str | None = None
         self.sources: list[str] | None = None

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -17,6 +17,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 async def test_flow_no_blocks(hass: HomeAssistant):
     flow = DynamicEnergyCalculatorConfigFlow()
     flow.hass = hass
+    flow.context = {}
 
     result = await flow.async_step_user({CONF_SOURCE_TYPE: "finish"})
     assert result["type"] == FlowResultType.FORM
@@ -26,6 +27,7 @@ async def test_flow_no_blocks(hass: HomeAssistant):
 async def test_full_flow(hass: HomeAssistant):
     flow = DynamicEnergyCalculatorConfigFlow()
     flow.hass = hass
+    flow.context = {}
 
     async def _get_energy():
         return ["sensor.energy"]
@@ -48,6 +50,7 @@ async def test_full_flow(hass: HomeAssistant):
 async def test_single_instance_abort(hass: HomeAssistant):
     flow = DynamicEnergyCalculatorConfigFlow()
     flow.hass = hass
+    flow.context = {}
 
     entry = MockConfigEntry(domain=DOMAIN, data={}, entry_id="1")
     entry.add_to_hass(hass)


### PR DESCRIPTION
## Summary
- remove manual `self.context` dictionary creation in config flow
- fix tests to initialize context explicitly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d26751fe483238ce459610a1e4943