### PR TITLE
Handle recovering sensors

### DIFF
--- a/custom_components/dynamic_energy_contract_calculator/repair.py
+++ b/custom_components/dynamic_energy_contract_calculator/repair.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import logging
 
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
+from homeassistant.helpers.issue_registry import (
+    IssueSeverity,
+    async_create_issue,
+    async_delete_issue,
+)
 
 from .const import DOMAIN
 
@@ -29,3 +33,11 @@ def async_report_issue(
         )
     except Exception as err:  # pragma: no cover - issue registry may not be loaded
         _LOGGER.debug("Failed to create issue %s: %s", issue_id, err)
+
+
+def async_clear_issue(hass: HomeAssistant, issue_id: str) -> None:
+    """Delete a repair issue for this integration."""
+    try:
+        async_delete_issue(hass, DOMAIN, issue_id)
+    except Exception as err:  # pragma: no cover - issue registry may not be loaded
+        _LOGGER.debug("Failed to delete issue %s: %s", issue_id, err)


### PR DESCRIPTION
## Summary
- clear repair issues once sensors recover
- wait before flagging a sensor as unavailable
- test edge cases for recovering sensors

## Testing
- `pre-commit run --files custom_components/dynamic_energy_contract_calculator/entity.py custom_components/dynamic_energy_contract_calculator/repair.py tests/test_entity_edge_cases.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dd2d4abe88323b42f8e81a342c872