### PR TITLE
Allow multiple integration instances

### DIFF
--- a/custom_components/dynamic_energy_contract_calculator/sensor.py
+++ b/custom_components/dynamic_energy_contract_calculator/sensor.py
@@ -506,7 +506,7 @@ async def async_setup_entry(
             state = hass.states.get(sensor)
             friendly_name = state.attributes.get("friendly_name") if state else sensor
             device_info = DeviceInfo(
-                identifiers={(DOMAIN, base_id)},
+                identifiers={(DOMAIN, f"{entry.entry_id}_{base_id}")},
                 name=f"{DOMAIN_ABBREVIATION}: {friendly_name}",
                 entry_type=DeviceEntryType.SERVICE,
                 manufacturer="DynamicEnergyCalc",
@@ -515,7 +515,7 @@ async def async_setup_entry(
 
             for mode_def in mode_defs:
                 mode = mode_def["key"]
-                uid = f"{DOMAIN}_{base_id}_{mode}"
+                uid = f"{DOMAIN}_{entry.entry_id}_{base_id}_{mode}"
                 entities.append(
                     DynamicEnergySensor(
                         hass=hass,
@@ -536,9 +536,9 @@ async def async_setup_entry(
     UTILITY_ENTITIES.extend(entities)
 
     base_id = "daily_electricity_cost"
-    unique_id = f"{DOMAIN}_{base_id}"
+    unique_id = f"{DOMAIN}_{entry.entry_id}_{base_id}"
     device_info = DeviceInfo(
-        identifiers={(DOMAIN, base_id)},
+        identifiers={(DOMAIN, f"{entry.entry_id}_{base_id}")},
         name=f"{DOMAIN_ABBREVIATION}: Summary Sensors",
         entry_type=DeviceEntryType.SERVICE,
         manufacturer="DynamicEnergyCalc",
@@ -557,7 +557,7 @@ async def async_setup_entry(
     daily_gas = DailyGasCostSensor(
         hass=hass,
         name="Gas Contract Fixed Costs (Total)",
-        unique_id=f"{DOMAIN}_daily_gas_cost",
+        unique_id=f"{DOMAIN}_{entry.entry_id}_daily_gas_cost",
         price_settings=price_settings,
         device=device_info,
     )
@@ -566,7 +566,7 @@ async def async_setup_entry(
     net_cost = TotalCostSensor(
         hass=hass,
         name="Net Energy Cost (Total)",
-        unique_id=f"{DOMAIN}_net_total_cost",
+        unique_id=f"{DOMAIN}_{entry.entry_id}_net_total_cost",
         device=device_info,
     )
     entities.append(net_cost)
@@ -574,7 +574,7 @@ async def async_setup_entry(
     energy_cost = TotalEnergyCostSensor(
         hass=hass,
         name="Energy Contract Cost (Total)",
-        unique_id=f"{DOMAIN}_total_energy_cost",
+        unique_id=f"{DOMAIN}_{entry.entry_id}_total_energy_cost",
         net_cost_unique_id=net_cost.unique_id,
         fixed_cost_unique_ids=[daily_electricity.unique_id, daily_gas.unique_id],
         device=device_info,
@@ -587,7 +587,7 @@ async def async_setup_entry(
             CurrentElectricityPriceSensor(
                 hass=hass,
                 name="Current Consumption Price",
-                unique_id=f"{DOMAIN}_current_consumption_price",
+                unique_id=f"{DOMAIN}_{entry.entry_id}_current_consumption_price",
                 price_sensor=price_sensor,
                 source_type=SOURCE_TYPE_CONSUMPTION,
                 price_settings=price_settings,
@@ -599,7 +599,7 @@ async def async_setup_entry(
             CurrentElectricityPriceSensor(
                 hass=hass,
                 name="Current Production Price",
-                unique_id=f"{DOMAIN}_current_production_price",
+                unique_id=f"{DOMAIN}_{entry.entry_id}_current_production_price",
                 price_sensor=price_sensor,
                 source_type=SOURCE_TYPE_PRODUCTION,
                 price_settings=price_settings,
@@ -614,7 +614,7 @@ async def async_setup_entry(
             CurrentElectricityPriceSensor(
                 hass=hass,
                 name="Current Gas Consumption Price",
-                unique_id=f"{DOMAIN}_current_gas_consumption_price",
+                unique_id=f"{DOMAIN}_{entry.entry_id}_current_gas_consumption_price",
                 price_sensor=price_sensor_gas,
                 source_type=SOURCE_TYPE_GAS,
                 price_settings=price_settings,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,5 +10,8 @@ async def set_time_zone(hass):
     os.environ["TZ"] = "America/Los_Angeles"
     if hasattr(time, "tzset"):
         time.tzset()
-    await hass.config.async_set_time_zone("America/Los_Angeles")
+    if hasattr(hass.config, "async_set_time_zone"):
+        await hass.config.async_set_time_zone("America/Los_Angeles")
+    else:
+        hass.config.set_time_zone("America/Los_Angeles")
     yield

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -47,7 +47,7 @@ async def test_full_flow(hass: HomeAssistant):
     ]
 
 
-async def test_single_instance_abort(hass: HomeAssistant):
+async def test_multiple_instances_allowed(hass: HomeAssistant):
     flow = DynamicEnergyCalculatorConfigFlow()
     flow.hass = hass
     flow.context = {}
@@ -56,5 +56,4 @@ async def test_single_instance_abort(hass: HomeAssistant):
     entry.add_to_hass(hass)
 
     result = await flow.async_step_user()
-    assert result["type"] == FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result["type"] == FlowResultType.FORM

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -48,27 +48,22 @@ async def test_service_handlers(hass: HomeAssistant):
     }
     hass.states.async_set("dynamic_energy_contract_calculator.test", 1)
 
-    await _handle_reset_all(ServiceCall(hass, DOMAIN, "reset_all_meters", {}))
+    class FakeCall:
+        def __init__(self, data):
+            self.hass = hass
+            self.data = data
+
+    await _handle_reset_all(FakeCall({}))
     assert called["reset"]
 
     called["reset"] = False
     await _handle_reset_sensors(
-        ServiceCall(
-            hass,
-            DOMAIN,
-            "reset_selected_meters",
-            {"entity_ids": ["dynamic_energy_contract_calculator.test"]},
-        )
+        FakeCall({"entity_ids": ["dynamic_energy_contract_calculator.test"]})
     )
     assert called["reset"]
 
     await _handle_set_value(
-        ServiceCall(
-            hass,
-            DOMAIN,
-            "set_meter_value",
-            {"entity_id": "dynamic_energy_contract_calculator.test", "value": 5},
-        )
+        FakeCall({"entity_id": "dynamic_energy_contract_calculator.test", "value": 5})
     )
     assert called["set"] == 5
 


### PR DESCRIPTION
## Summary
- make config flow support multiple entries
- include entry_id in unique IDs
- hide gas price fields unless a gas source is configured
- fix timezone fixture for older Home Assistant
- adjust service tests for newer ServiceCall API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e1cb5b87c83238ada48c819e4b251