### PR TITLE
Add heat pump power sensors

### DIFF
--- a/custom_components/dynamic_energy_contract_calculator/translations/en.json
+++ b/custom_components/dynamic_energy_contract_calculator/translations/en.json
@@ -119,7 +119,9 @@
       "total_energy_cost": {"name": "Energy Contract Cost (Total)"},
       "current_consumption_price": {"name": "Current Consumption Price"},
       "current_production_price": {"name": "Current Production Price"},
-      "current_gas_consumption_price": {"name": "Current Gas Consumption Price"}
+      "current_gas_consumption_price": {"name": "Current Gas Consumption Price"},
+      "cop": {"name": "Coefficient of Performance"},
+      "current_thermal_power": {"name": "Current Thermal Power"}
     }
     },
     "issues": {

--- a/custom_components/dynamic_energy_contract_calculator/translations/nl.json
+++ b/custom_components/dynamic_energy_contract_calculator/translations/nl.json
@@ -145,6 +145,12 @@
       },
       "current_gas_consumption_price": {
         "name": "Huidige gasverbruiksprijs"
+      },
+      "cop": {
+        "name": "Rendementsfactor"
+      },
+      "current_thermal_power": {
+        "name": "Huidig thermisch vermogen"
       }
     }
   },


### PR DESCRIPTION
## Summary
- calculate COP using outside and supply temperatures
- add COP and thermal power sensors
- expose translations for new sensors
- test new heat pump sensors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688670a1419c8323ae5059783edf12c8